### PR TITLE
Fix monitor signaling % to use full-period denominator

### DIFF
--- a/web/src/components/MonitorDashboard.tsx
+++ b/web/src/components/MonitorDashboard.tsx
@@ -466,6 +466,10 @@ function clampPercent(value: number) {
   return Math.min(Math.max(value, 0), 100);
 }
 
+function lockedInSignalPct(data: MonitorData): number {
+  return (data.signalingCount / PERIOD_BLOCK_COUNT) * 100;
+}
+
 function blockDetailUnavailable(block: PeriodGridBlock) {
   return (
     block.hash === undefined ||
@@ -529,7 +533,7 @@ function currentPeriodFromMonitorData(data: MonitorData): Period {
     endBlock: data.periodEnd,
     signalingCount: data.signalingCount,
     totalBlocks: data.totalBlocks,
-    pct: data.pct,
+    pct: lockedInSignalPct(data),
   };
 }
 
@@ -836,8 +840,8 @@ export function MonitorHighlights() {
     return [
       {
         label: "Signal rate",
-        value: formatPercent(data.pct),
-        detail: `${formatNumber(data.signalingCount)} of ${formatNumber(data.totalBlocks)} blocks`,
+        value: formatPercent(lockedInSignalPct(data)),
+        detail: `${formatNumber(data.signalingCount)} of ${formatNumber(PERIOD_BLOCK_COUNT)} blocks`,
       },
       {
         label: "Blocks left",
@@ -1516,7 +1520,8 @@ export function MonitorDashboard() {
 
     const blocksLeft = Math.max(data.periodEnd - data.tip, 0);
     const periodProgress = (data.totalBlocks / PERIOD_BLOCK_COUNT) * 100;
-    const activationProgress = (data.pct / ACTIVATION_THRESHOLD) * 100;
+    const lockedInPct = lockedInSignalPct(data);
+    const activationProgress = (lockedInPct / ACTIVATION_THRESHOLD) * 100;
     const signalingDeficit = Math.max(
       REQUIRED_SIGNALING_BLOCKS - data.signalingCount,
       0,
@@ -1526,6 +1531,7 @@ export function MonitorDashboard() {
     return {
       blocksLeft,
       periodProgress,
+      lockedInPct,
       activationProgress,
       signalingDeficit,
       historyPeriods,
@@ -1679,7 +1685,7 @@ export function MonitorDashboard() {
         />
         <StatusCard
           label="Signal rate"
-          value={formatPercent(data.pct)}
+          value={formatPercent(stats.lockedInPct)}
           detail={`Current period target is ${ACTIVATION_THRESHOLD}%`}
           tone="primary"
         />
@@ -1744,9 +1750,9 @@ export function MonitorDashboard() {
 
             <div className="space-y-5">
               <ProgressRow
-                label="Signaling rate"
-                value={formatPercent(data.pct)}
-                detail={`${formatNumber(data.signalingCount)} signaling blocks, ${formatNumber(stats.signalingDeficit)} more needed for lock-in`}
+                label="Signaling progress"
+                value={formatPercent(stats.lockedInPct)}
+                detail={`${formatNumber(data.signalingCount)} of ${formatNumber(PERIOD_BLOCK_COUNT)} blocks, ${formatNumber(stats.signalingDeficit)} more needed for lock-in`}
                 percent={stats.activationProgress}
               />
               <ProgressRow

--- a/web/src/worker/monitor-data.ts
+++ b/web/src/worker/monitor-data.ts
@@ -172,9 +172,11 @@ export function parseMonitorData(value: unknown): MonitorData {
     updatedAt: stringField(value, "updatedAt"),
   };
 
+  const lockedInPct = (data.signalingCount / PERIOD_SIZE) * 100;
   const normalizedData = {
     ...data,
-    periods: monitorPeriods(data),
+    pct: lockedInPct,
+    periods: monitorPeriods({ ...data, pct: lockedInPct }),
   };
 
   if (!isReasonableMonitorData(normalizedData)) {


### PR DESCRIPTION
The monitor's signaling percentage for the current period used a moving denominator: the upstream API reports the in-progress period with `totalBlocks` equal to blocks mined so far, so `pct = signaling / blocksSoFar`. Completed periods and the 55% lock-in threshold are measured against the full 2016 blocks, so the headline appeared to drop when a period closed (e.g. 1.04% mid-period settling to 0.99% at the end) even though nothing changed.

This normalizes the current-period percentage to `signalingCount / 2016`, matching completed periods and the activation threshold. The number is now monotonic within a period and identical the moment the period closes.

Changes:
- `worker/monitor-data.ts`: normalize `pct` at the single parse point, so the worker-rendered page, OG image, and social metadata are consistent.
- `components/MonitorDashboard.tsx`: compute the headline and activation progress from `signaling / 2016` directly (dev bypasses the worker and hits upstream), and relabel the progress row "Signaling progress".

Verified in a headless browser against a crafted partial period (21 signaling of 1000 blocks mined): headline renders 1.04% and stays there through period end, instead of the old 2.10% running rate.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected current-period signal rate calculations to use the number of signaling blocks within the defined period.
  * Updated signaling progress and activation indicators to reflect the corrected locked-in percentage.
  * Aligned signal rate details and period summaries so displayed values are consistent across the dashboard.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->